### PR TITLE
fix(pocket-change.js): update sheetClass used for new actor data after conversion

### DIFF
--- a/scripts/pocket-change.js
+++ b/scripts/pocket-change.js
@@ -217,7 +217,7 @@ export default class PocketChange {
     let newActorData = {
       flags: {
         core: {
-          sheetClass: 'dnd5e.LootSheetNPC5e',
+          sheetClass: 'dnd5e.dnd5e.LootSheet5eNPC',
         },
         lootsheetnpc5e: {
           lootsheettype: 'Loot',


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
The name of the sheetClass used by LootSheetNPC5e seems to have changed. With this change the new actor data should behave as expected and properly set the sheet to a loot sheet


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This should fix #44 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, all functionally works, except the step where we should set the current token sheet to a loot sheet. With this change the behaviour is reinstated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I manually made the change on my foundry instance and it seems that worked well. Unfortunely I don't know any way to get some unit tests for this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
