### PR TITLE
fix(pocket-change.js): wrong sheetClass name

### DIFF
--- a/scripts/pocket-change.js
+++ b/scripts/pocket-change.js
@@ -217,7 +217,7 @@ export default class PocketChange {
     let newActorData = {
       flags: {
         core: {
-          sheetClass: 'dnd5e.LootSheetNPC5e',
+          sheetClass: 'dnd5e.dnd5e.LootSheet5eNPC',
         },
         lootsheetnpc5e: {
           lootsheettype: 'Loot',

--- a/scripts/pocket-change.js
+++ b/scripts/pocket-change.js
@@ -217,7 +217,7 @@ export default class PocketChange {
     let newActorData = {
       flags: {
         core: {
-          sheetClass: 'dnd5e.dnd5e.LootSheet5eNPC',
+          sheetClass: 'dnd5e.LootSheet5eNPC',
         },
         lootsheetnpc5e: {
           lootsheettype: 'Loot',


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
There was an additional `dnd5e.` on the entry. 

Sorry about the bad commit, it seems I did not stage things properly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No open issue, but is related to #44 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If this is released as is, the problem described on the related issue will keep happening.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
